### PR TITLE
feat: slice 3 menu discovery + debugging + repo cleanup

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,9 +1,5 @@
-# CodeRabbit configuration for a Active Plugin Locator plugin repo.
-# Keep this lean; add only when it measurably improves signal.
-
 language: en-US
 
-# Keep tone professional and aligned with our workflow.
 tone_instructions: >
   You are a senior WordPress plugin engineer, security reviewer, and QA lead.
   Accuracy > coverage. Do not guess. Prefer small patches over rewrites.
@@ -18,22 +14,22 @@ reviews:
   commit_status: true
   fail_commit_status: false
   collapse_walkthrough: true
+  review_status: true
 
   auto_review:
     enabled: true
     auto_incremental_review: true
 
-  # Keep focus tight: only review relevant code paths.
   path_filters:
     - "active-plugin-locator.php"
     - "includes/**"
     - "assets/**"
+    - "!public/wp-content/**"
     - "!vendor/**"
     - "!node_modules/**"
     - "!.ddev/**"
     - "!.github/**"
 
-  # Give file-specific guidance where it matters.
   path_instructions:
     - path: "includes/**/*.php"
       instructions: >
@@ -55,7 +51,4 @@ reviews:
     - path: "assets/**/*.css"
       instructions: >
         Keep CSS scoped to the toast root to avoid wp-admin collisions.
-
-ignore:
-  - "vendor/**"
-  - "node_modules/**"
+        

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,22 @@
 /vendor/
+
+# WordPress runtime
+public/wp-content/plugins/
+public/wp-content/uploads/
+public/wp-content/cache/
+public/wp-content/debug.log
+public/wp-content/autoptimize_404_handler.php
+
+/public/wp-content/
+/public/wp-content/debug.log
+/public/wp-content/cache/
+/public/wp-content/uploads/
+/public/wp-content/plugins/
+/public/wp-content/themes/
+
+# DDEV / local
+.vendor/
+node_modules/
+
+# OS
+.DS_Store

--- a/active-plugin-locator.php
+++ b/active-plugin-locator.php
@@ -3,14 +3,14 @@
  * Plugin Name: Active Plugin Locator
  * Description: Shows a one-time admin toast after plugin activation indicating where to manage the plugin (when detectable).
  * Version: 0.1.0
- * Author: Your Name
+ * Author: Cyber-Creator
  * Text Domain: active-plugin-locator
  *
  * @package ActivePluginLocator
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 define( 'APL_VERSION', '0.1.0' );
@@ -19,7 +19,10 @@ define( 'APL_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'APL_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
 require_once APL_PLUGIN_DIR . 'includes/class-apl-activation-queue.php';
+require_once APL_PLUGIN_DIR . 'includes/class-apl-menu-discovery.php';
+require_once APL_PLUGIN_DIR . 'includes/class-apl-row-action-discovery.php';
 require_once APL_PLUGIN_DIR . 'includes/class-apl-admin-toast.php';
+
 
 add_action(
 	'plugins_loaded',

--- a/assets/admin-toast.js
+++ b/assets/admin-toast.js
@@ -46,6 +46,25 @@
 
     li.appendChild(name);
     li.appendChild(msg);
+
+    if (Array.isArray(item.links) && item.links.length > 0) {
+      const linksList = document.createElement("ul");
+      linksList.className = "apl-toast__links";
+
+      item.links.forEach((linkItem) => {
+        const linkLi = document.createElement("li");
+
+        const anchor = document.createElement("a");
+        anchor.href = linkItem.url;
+        anchor.textContent = linkItem.label || linkItem.url;
+
+        linkLi.appendChild(anchor);
+        linksList.appendChild(linkLi);
+      });
+
+      li.appendChild(linksList);
+    }
+
     list.appendChild(li);
   });
 
@@ -56,12 +75,10 @@
 
   root.appendChild(toast);
 
-  // Auto-hide after ~10s (still dismissible).
   window.setTimeout(() => {
     if (toast && toast.parentNode) toast.remove();
   }, 10000);
 
-  // ESC closes.
   window.addEventListener("keydown", (e) => {
     if (e.key === "Escape" && toast && toast.parentNode) toast.remove();
   });

--- a/bin/sync-plugin.sh
+++ b/bin/sync-plugin.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST="$ROOT/public/wp-content/plugins/active-plugin-locator"
+
+mkdir -p "$DEST"
+
+rsync -av --delete \
+  --exclude '.git/' \
+  --exclude '.github/' \
+  --exclude '.ddev/' \
+  --exclude 'public/' \
+  --exclude 'vendor/' \
+  --exclude 'node_modules/' \
+  "$ROOT"/ "$DEST"/

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
   },
   "scripts": {
     "lint": "phpcs -q",
-    "lint:report": "phpcs"
+    "lint:report": "phpcs",
+    "fix": "phpcbf"
   }
 }

--- a/includes/class-apl-activation-queue.php
+++ b/includes/class-apl-activation-queue.php
@@ -65,6 +65,23 @@ final class APL_Activation_Queue {
 	}
 
 	/**
+	 * Read the current user's queue without clearing it.
+	 *
+	 * @return array<int, string>
+	 */
+	public static function peek_for_current_user(): array {
+		$user_id = get_current_user_id();
+		if ( 0 >= $user_id ) {
+			return array();
+		}
+
+		$key   = self::key_for_user( $user_id );
+		$queue = get_transient( $key );
+
+		return is_array( $queue ) ? array_values( array_filter( $queue, 'is_string' ) ) : array();
+	}
+
+	/**
 	 * Consume and clear the current user's queue (one-time behavior).
 	 *
 	 * @return array<int, string>

--- a/includes/class-apl-admin-toast.php
+++ b/includes/class-apl-admin-toast.php
@@ -17,11 +17,25 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class APL_Admin_Toast {
 
 	/**
-	 * Cached payload for this request after consuming queue.
+	 * Pending plugin basenames for this request.
 	 *
-	 * @var array<string, mixed>|null
+	 * @var array<int, string>
 	 */
-	private static $payload = null;
+	private static $pending_plugins = array();
+
+	/**
+	 * High-confidence menu discovery helper.
+	 *
+	 * @var APL_Menu_Discovery|null
+	 */
+	private static $menu_discovery = null;
+
+	/**
+	 * Medium-confidence row action discovery helper.
+	 *
+	 * @var APL_Row_Action_Discovery|null
+	 */
+	private static $row_action_discovery = null;
 
 	/**
 	 * Register hooks.
@@ -31,8 +45,9 @@ final class APL_Admin_Toast {
 	public static function init(): void {
 		add_action( 'activated_plugin', array( __CLASS__, 'on_single_activation' ), 10, 2 );
 		add_action( 'activated_plugins', array( __CLASS__, 'on_bulk_activation' ), 10, 1 );
-
-		add_action( 'admin_init', array( __CLASS__, 'prepare_payload_once' ) );
+		// Temporarily disable Slice 3 until the runtime fatal is isolated.
+		add_action( 'admin_menu', array( __CLASS__, 'capture_menu_candidates' ), PHP_INT_MAX );
+		add_action( 'admin_init', array( __CLASS__, 'prepare_pending_plugins' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
 		add_action( 'admin_footer', array( __CLASS__, 'render_mount' ) );
 	}
@@ -40,12 +55,11 @@ final class APL_Admin_Toast {
 	/**
 	 * Handle single plugin activation.
 	 *
-	 * @param string $plugin       Plugin basename (e.g., hello-dolly/hello.php).
-	 * @param bool   $network_wide Whether activated network-wide (unused in V1).
+	 * @param string $plugin       Plugin basename.
+	 * @param bool   $network_wide Whether activated network-wide.
 	 * @return void
 	 */
 	public static function on_single_activation( string $plugin, bool $network_wide ): void {
-		// Kept for hook signature compatibility.
 		unset( $network_wide );
 
 		if ( ! current_user_can( 'activate_plugins' ) ) {
@@ -56,7 +70,7 @@ final class APL_Admin_Toast {
 	}
 
 	/**
-	 * Handle bulk activation of plugins.
+	 * Handle bulk plugin activation.
 	 *
 	 * @param array<int, string> $plugins Plugin basenames.
 	 * @return void
@@ -70,29 +84,98 @@ final class APL_Admin_Toast {
 	}
 
 	/**
-	 * Prepare toast payload once per activation queue consumption.
+	 * Load pending plugins for this request if needed.
 	 *
 	 * @return void
 	 */
-	public static function prepare_payload_once(): void {
-		if ( ! current_user_can( 'activate_plugins' ) ) {
+	private static function ensure_pending_plugins_loaded(): void {
+		if ( ! empty( self::$pending_plugins ) ) {
 			return;
 		}
 
-		if ( ! is_admin() ) {
+		if ( ! is_admin() || ! current_user_can( 'activate_plugins' ) ) {
 			return;
 		}
 
-		$queue = APL_Activation_Queue::consume_for_current_user();
-		if ( empty( $queue ) ) {
+		self::$pending_plugins = APL_Activation_Queue::peek_for_current_user();
+	}
+
+	/**
+	 * Capture high-confidence menu candidates from registered admin menus.
+	 *
+	 * @return void
+	 */
+	public static function capture_menu_candidates(): void {
+		self::ensure_pending_plugins_loaded();
+
+		if ( empty( self::$pending_plugins ) ) {
 			return;
 		}
 
+		if ( ! class_exists( 'APL_Menu_Discovery' ) ) {
+			return;
+		}
+
+		self::$menu_discovery = new APL_Menu_Discovery( self::$pending_plugins );
+		self::$menu_discovery->capture_from_registered_menus();
+	}
+
+	/**
+	 * Prepare medium-confidence row action discovery for this request.
+	 *
+	 * @return void
+	 */
+	public static function prepare_pending_plugins(): void {
+		self::ensure_pending_plugins_loaded();
+
+		if ( empty( self::$pending_plugins ) ) {
+			return;
+		}
+
+		self::$row_action_discovery = new APL_Row_Action_Discovery( self::$pending_plugins );
+		self::$row_action_discovery->register();
+	}
+
+	/**
+	 * Enqueue toast assets only when a queue exists.
+	 *
+	 * @return void
+	 */
+	public static function enqueue_assets(): void {
+		self::ensure_pending_plugins_loaded();
+
+		if ( empty( self::$pending_plugins ) ) {
+			return;
+		}
+
+		wp_enqueue_style(
+			'apl-admin-toast',
+			APL_PLUGIN_URL . 'assets/admin-toast.css',
+			array(),
+			APL_VERSION
+		);
+
+		wp_enqueue_script(
+			'apl-admin-toast',
+			APL_PLUGIN_URL . 'assets/admin-toast.js',
+			array(),
+			APL_VERSION,
+			true
+		);
+	}
+
+	/**
+	 * Build the final toast payload.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function build_payload(): array {
 		$items = array();
-		foreach ( $queue as $basename ) {
-			$data = get_plugin_data( WP_PLUGIN_DIR . '/' . $basename, false, false );
 
+		foreach ( self::$pending_plugins as $basename ) {
+			$data = get_plugin_data( WP_PLUGIN_DIR . '/' . $basename, false, false );
 			$name = '';
+
 			if ( is_array( $data ) && ! empty( $data['Name'] ) ) {
 				$name = (string) $data['Name'];
 			}
@@ -101,19 +184,54 @@ final class APL_Admin_Toast {
 				$name = $basename;
 			}
 
+			$high_candidates = array();
+			if ( self::$menu_discovery instanceof APL_Menu_Discovery ) {
+				$high_candidates = self::$menu_discovery->get_candidates( $basename );
+			}
+
+			if ( ! empty( $high_candidates ) ) {
+				$items[] = array(
+					'plugin'  => $basename,
+					'name'    => $name,
+					'message' => ( 1 === count( $high_candidates ) )
+						? __( 'Manage in:', 'active-plugin-locator' )
+						: __( 'We found multiple management locations:', 'active-plugin-locator' ),
+					'links'   => $high_candidates,
+				);
+
+				continue;
+			}
+
+			$medium_candidates = array();
+			if ( self::$row_action_discovery instanceof APL_Row_Action_Discovery ) {
+				$medium_candidates = self::$row_action_discovery->get_candidates( $basename );
+			}
+
+			if ( ! empty( $medium_candidates ) ) {
+				$items[] = array(
+					'plugin'  => $basename,
+					'name'    => $name,
+					'message' => ( 1 === count( $medium_candidates ) )
+						? __( 'Likely manage here:', 'active-plugin-locator' )
+						: __( 'We found multiple likely locations:', 'active-plugin-locator' ),
+					'links'   => $medium_candidates,
+				);
+
+				continue;
+			}
+
 			$items[] = array(
 				'plugin'  => $basename,
 				'name'    => $name,
-				// Slice 1: conservative default (no discovery yet).
 				'message' => __( 'No admin settings page detected. It may run automatically or appear elsewhere.', 'active-plugin-locator' ),
 			);
 		}
 
-		self::$payload = array(
+		return array(
 			'title' => ( 1 === count( $items ) )
 				? __( 'Plugin activated', 'active-plugin-locator' )
 				: sprintf(
-					/* translators: %d = number of plugins activated */
+					/* translators: %d: number of activated plugins. */
 					__( '%d plugins activated', 'active-plugin-locator' ),
 					count( $items )
 				),
@@ -122,54 +240,34 @@ final class APL_Admin_Toast {
 	}
 
 	/**
-	 * Enqueue toast assets when a payload exists.
-	 *
-	 * @return void
-	 */
-	public static function enqueue_assets(): void {
-		if ( empty( self::$payload ) ) {
-			return;
-		}
-
-		$handle = 'apl-admin-toast';
-
-		wp_enqueue_style(
-			$handle,
-			APL_PLUGIN_URL . 'assets/admin-toast.css',
-			array(),
-			APL_VERSION
-		);
-
-		wp_enqueue_script(
-			$handle,
-			APL_PLUGIN_URL . 'assets/admin-toast.js',
-			array(),
-			APL_VERSION,
-			true
-		);
-
-		wp_localize_script(
-			$handle,
-			'APL_TOAST_DATA',
-			array(
-				'payload' => self::$payload,
-				'i18n'    => array(
-					'close' => __( 'Dismiss', 'active-plugin-locator' ),
-				),
-			)
-		);
-	}
-
-	/**
-	 * Render the toast mount point.
+	 * Render the toast mount point and inject payload.
 	 *
 	 * @return void
 	 */
 	public static function render_mount(): void {
-		if ( empty( self::$payload ) ) {
+		self::ensure_pending_plugins_loaded();
+
+		if ( empty( self::$pending_plugins ) ) {
 			return;
 		}
 
+		$payload = self::build_payload();
+
+		wp_add_inline_script(
+			'apl-admin-toast',
+			'window.APL_TOAST_DATA = ' . wp_json_encode(
+				array(
+					'payload' => $payload,
+					'i18n'    => array(
+						'close' => __( 'Dismiss', 'active-plugin-locator' ),
+					),
+				)
+			) . ';',
+			'before'
+		);
+
 		echo '<div id="apl-toast-root" aria-live="polite" aria-atomic="true"></div>';
+
+		APL_Activation_Queue::consume_for_current_user();
 	}
 }

--- a/includes/class-apl-menu-discovery.php
+++ b/includes/class-apl-menu-discovery.php
@@ -1,0 +1,537 @@
+<?php
+/**
+ * High-confidence menu discovery for Active Plugin Locator.
+ *
+ * @package ActivePluginLocator
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Captures high-confidence admin menu candidates by resolving page callbacks
+ * to files inside the activated plugin directory.
+ *
+ * @package ActivePluginLocator
+ */
+final class APL_Menu_Discovery {
+
+	/**
+	 * Pending plugin basenames.
+	 *
+	 * @var array<int, string>
+	 */
+	private $pending_plugins = array();
+
+	/**
+	 * Raw candidate results keyed by plugin basename.
+	 *
+	 * @var array<string, array<int, array<string, mixed>>>
+	 */
+	private $results = array();
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array<int, string> $pending_plugins Pending plugin basenames.
+	 */
+	public function __construct( array $pending_plugins ) {
+		$this->pending_plugins = array_values(
+			array_unique(
+				array_filter( $pending_plugins, 'is_string' )
+			)
+		);
+	}
+
+	/**
+	 * Capture candidates from the currently registered admin menus.
+	 *
+	 * @return void
+	 */
+	public function capture_from_registered_menus(): void {
+		global $menu, $submenu;
+
+		if ( empty( $this->pending_plugins ) ) {
+			return;
+		}
+
+		$parent_labels = $this->build_parent_labels( is_array( $menu ) ? $menu : array() );
+
+		if ( is_array( $menu ) ) {
+			foreach ( $menu as $entry ) {
+				if ( ! is_array( $entry ) ) {
+					continue;
+				}
+
+				$candidate = $this->build_candidate_from_menu_entry( '', $entry, $parent_labels );
+				if ( empty( $candidate ) ) {
+					continue;
+				}
+
+				$this->store_candidate( $candidate );
+			}
+		}
+
+		if ( is_array( $submenu ) ) {
+			foreach ( $submenu as $parent_slug => $entries ) {
+				if ( ! is_array( $entries ) ) {
+					continue;
+				}
+
+				foreach ( $entries as $entry ) {
+					if ( ! is_array( $entry ) ) {
+						continue;
+					}
+
+					$candidate = $this->build_candidate_from_menu_entry( (string) $parent_slug, $entry, $parent_labels );
+					if ( empty( $candidate ) ) {
+						continue;
+					}
+
+					$this->store_candidate( $candidate );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Return sorted, deduplicated candidates for a plugin.
+	 *
+	 * @param string $plugin_file Plugin basename.
+	 * @return array<int, array<string, string>>
+	 */
+	public function get_candidates( string $plugin_file ): array {
+		$candidates = isset( $this->results[ $plugin_file ] ) ? $this->results[ $plugin_file ] : array();
+
+		if ( empty( $candidates ) ) {
+			return array();
+		}
+
+		usort(
+			$candidates,
+			static function ( array $left, array $right ): int {
+				return (int) $right['score'] <=> (int) $left['score'];
+			}
+		);
+
+		$deduped = array();
+		$seen    = array();
+
+		foreach ( $candidates as $candidate ) {
+			$dedupe_key = $candidate['url'];
+
+			if ( isset( $seen[ $dedupe_key ] ) ) {
+				continue;
+			}
+
+			$seen[ $dedupe_key ] = true;
+			$deduped[]           = array(
+				'label' => $candidate['label'],
+				'url'   => $candidate['url'],
+			);
+
+			if ( 3 <= count( $deduped ) ) {
+				break;
+			}
+		}
+
+		return $deduped;
+	}
+
+	/**
+	 * Store a raw candidate.
+	 *
+	 * @param array<string, mixed> $candidate Candidate data.
+	 * @return void
+	 */
+	private function store_candidate( array $candidate ): void {
+		$plugin_file = (string) $candidate['plugin'];
+
+		if ( ! isset( $this->results[ $plugin_file ] ) ) {
+			$this->results[ $plugin_file ] = array();
+		}
+
+		$this->results[ $plugin_file ][] = $candidate;
+	}
+
+	/**
+	 * Build a label map for top-level parents.
+	 *
+	 * @param array<int|string, mixed> $menu Registered top-level menu array.
+	 * @return array<string, string>
+	 */
+	private function build_parent_labels( array $menu ): array {
+		$labels = array();
+
+		foreach ( $menu as $entry ) {
+			if ( ! is_array( $entry ) || empty( $entry[2] ) ) {
+				continue;
+			}
+
+			$slug  = (string) $entry[2];
+			$label = $this->normalize_menu_label( isset( $entry[0] ) ? (string) $entry[0] : '' );
+
+			if ( '' === $slug || '' === $label ) {
+				continue;
+			}
+
+			$labels[ $slug ] = $label;
+		}
+
+		return $labels;
+	}
+
+	/**
+	 * Build a high-confidence candidate from a menu or submenu entry.
+	 *
+	 * @param string                   $parent_slug   Parent menu slug.
+	 * @param array<int|string, mixed> $entry         Menu entry.
+	 * @param array<string, string>    $parent_labels Parent labels keyed by slug.
+	 * @return array<string, mixed>
+	 */
+	private function build_candidate_from_menu_entry( string $parent_slug, array $entry, array $parent_labels ): array {
+		$menu_slug  = isset( $entry[2] ) ? (string) $entry[2] : '';
+		$menu_label = $this->normalize_menu_label( isset( $entry[0] ) ? (string) $entry[0] : '' );
+
+		if ( '' === $menu_slug || '' === $menu_label ) {
+			return array();
+		}
+
+		$page_hook = $this->resolve_page_hook( $menu_slug, $parent_slug, $entry );
+		if ( '' === $page_hook ) {
+			$this->debug_log(
+				'',
+				'rejected',
+				'no_page_hook',
+				array(
+					'parent_slug' => $parent_slug,
+					'menu_slug'   => $menu_slug,
+					'menu_label'  => $menu_label,
+				)
+			);
+
+			return array();
+		}
+
+		$callback_files = $this->get_callback_files_for_page_hook( $page_hook );
+		if ( empty( $callback_files ) ) {
+			$this->debug_log(
+				'',
+				'rejected',
+				'no_callback_files',
+				array(
+					'page_hook'  => $page_hook,
+					'menu_slug'  => $menu_slug,
+					'menu_label' => $menu_label,
+				)
+			);
+
+			return array();
+		}
+
+		$url = menu_page_url( $menu_slug, false );
+		if ( '' === $url ) {
+			return array();
+		}
+
+		$url = esc_url_raw( html_entity_decode( $url, ENT_QUOTES, 'UTF-8' ) );
+
+		foreach ( $this->pending_plugins as $plugin_file ) {
+			if ( ! $this->can_use_high_confidence_for_plugin( $plugin_file ) ) {
+				continue;
+			}
+
+			foreach ( $callback_files as $callback_file ) {
+				if ( ! $this->callback_belongs_to_plugin( $plugin_file, $callback_file ) ) {
+					continue;
+				}
+
+				$candidate = array(
+					'plugin' => $plugin_file,
+					'label'  => $this->build_label_path( $parent_slug, $menu_label, $parent_labels ),
+					'url'    => $url,
+					'score'  => $this->score_candidate( $parent_slug, $menu_label ),
+				);
+
+				$this->debug_log(
+					$plugin_file,
+					'accepted',
+					'high_confidence_candidate',
+					array(
+						'label'         => $candidate['label'],
+						'url'           => $candidate['url'],
+						'page_hook'     => $page_hook,
+						'callback_file' => $callback_file,
+					)
+				);
+
+				return $candidate;
+			}
+		}
+
+		$this->debug_log(
+			'',
+			'rejected',
+			'callback_not_owned_by_pending_plugin',
+			array(
+				'parent_slug'    => $parent_slug,
+				'menu_slug'      => $menu_slug,
+				'menu_label'     => $menu_label,
+				'page_hook'      => $page_hook,
+				'callback_files' => $callback_files,
+			)
+		);
+
+		return array();
+	}
+
+	/**
+	 * Resolve the page hook for a menu entry.
+	 *
+	 * @param string                   $menu_slug   Menu slug.
+	 * @param string                   $parent_slug Parent slug.
+	 * @param array<int|string, mixed> $entry       Menu entry.
+	 * @return string
+	 */
+	private function resolve_page_hook( string $menu_slug, string $parent_slug, array $entry ): string {
+		if ( '' === $parent_slug ) {
+			$hook = isset( $entry[5] ) ? (string) $entry[5] : '';
+			if ( '' !== $hook ) {
+				return $hook;
+			}
+
+			$page_hook = get_plugin_page_hook( $menu_slug, '' );
+
+			return is_string( $page_hook ) ? $page_hook : '';
+		}
+
+		$page_hook = get_plugin_page_hook( $menu_slug, $parent_slug );
+
+		return is_string( $page_hook ) ? $page_hook : '';
+	}
+
+	/**
+	 * Get callback file paths attached to a page hook.
+	 *
+	 * @param string $page_hook Page hook.
+	 * @return array<int, string>
+	 */
+	private function get_callback_files_for_page_hook( string $page_hook ): array {
+		global $wp_filter;
+
+		if ( ! isset( $wp_filter[ $page_hook ] ) || ! ( $wp_filter[ $page_hook ] instanceof WP_Hook ) ) {
+			return array();
+		}
+
+		$files = array();
+
+		foreach ( $wp_filter[ $page_hook ]->callbacks as $callbacks ) {
+			if ( ! is_array( $callbacks ) ) {
+				continue;
+			}
+
+			foreach ( $callbacks as $callback_data ) {
+				if ( empty( $callback_data['function'] ) ) {
+					continue;
+				}
+
+				$file = $this->resolve_callback_file( $callback_data['function'] );
+				if ( '' === $file ) {
+					continue;
+				}
+
+				$files[] = $file;
+			}
+		}
+
+		return array_values( array_unique( $files ) );
+	}
+
+	/**
+	 * Resolve a callback to the file where it is defined.
+	 *
+	 * @param callable|string|array $callback Callback definition.
+	 * @return string
+	 */
+	private function resolve_callback_file( $callback ): string {
+		try {
+			if ( is_array( $callback ) && 2 === count( $callback ) ) {
+				$reflection = new ReflectionMethod( $callback[0], (string) $callback[1] );
+			} elseif ( is_string( $callback ) && false !== strpos( $callback, '::' ) ) {
+				$parts = explode( '::', $callback, 2 );
+
+				if ( 2 !== count( $parts ) ) {
+					return '';
+				}
+
+				$reflection = new ReflectionMethod( $parts[0], $parts[1] );
+			} elseif ( $callback instanceof Closure || is_string( $callback ) ) {
+				$reflection = new ReflectionFunction( $callback );
+			} else {
+				return '';
+			}
+
+			$file = $reflection->getFileName();
+
+			return is_string( $file ) ? wp_normalize_path( $file ) : '';
+		} catch ( ReflectionException $exception ) {
+			return '';
+		}
+	}
+
+	/**
+	 * Whether a plugin basename can safely participate in high-confidence matching.
+	 *
+	 * @param string $plugin_file Plugin basename.
+	 * @return bool
+	 */
+	private function can_use_high_confidence_for_plugin( string $plugin_file ): bool {
+		return '' !== $this->get_plugin_root_path( $plugin_file );
+	}
+
+	/**
+	 * Get the normalized plugin root directory for a plugin basename.
+	 *
+	 * @param string $plugin_file Plugin basename.
+	 * @return string
+	 */
+	private function get_plugin_root_path( string $plugin_file ): string {
+		$plugin_dir = dirname( $plugin_file );
+
+		if ( '.' === $plugin_dir || '' === $plugin_dir ) {
+			return '';
+		}
+
+		return trailingslashit(
+			wp_normalize_path(
+				WP_PLUGIN_DIR . '/' . trim( $plugin_dir, '/' )
+			)
+		);
+	}
+
+	/**
+	 * Check whether a resolved callback file belongs to the plugin directory.
+	 *
+	 * @param string $plugin_file   Plugin basename.
+	 * @param string $callback_file Callback file.
+	 * @return bool
+	 */
+	private function callback_belongs_to_plugin( string $plugin_file, string $callback_file ): bool {
+		$plugin_root = $this->get_plugin_root_path( $plugin_file );
+
+		if ( '' === $plugin_root ) {
+			return false;
+		}
+
+		return 0 === strpos( wp_normalize_path( $callback_file ), $plugin_root );
+	}
+
+	/**
+	 * Normalize a menu label.
+	 *
+	 * @param string $label Raw menu label.
+	 * @return string
+	 */
+	private function normalize_menu_label( string $label ): string {
+		$label = preg_replace( '/\s+/', ' ', $label );
+		$label = is_string( $label ) ? $label : '';
+
+		return trim( wp_strip_all_tags( $label ) );
+	}
+
+	/**
+	 * Build a display path such as "Settings → Plugin".
+	 *
+	 * @param string                $parent_slug   Parent slug.
+	 * @param string                $menu_label    Menu label.
+	 * @param array<string, string> $parent_labels Parent labels.
+	 * @return string
+	 */
+	private function build_label_path( string $parent_slug, string $menu_label, array $parent_labels ): string {
+		if ( '' === $parent_slug || ! isset( $parent_labels[ $parent_slug ] ) ) {
+			return $menu_label;
+		}
+
+		$parent_label = $parent_labels[ $parent_slug ];
+
+		if ( $parent_label === $menu_label ) {
+			return $parent_label;
+		}
+
+		return $parent_label . ' → ' . $menu_label;
+	}
+
+	/**
+	 * Score a candidate for ordering only.
+	 *
+	 * @param string $parent_slug Parent slug.
+	 * @param string $menu_label  Menu label.
+	 * @return int
+	 */
+	private function score_candidate( string $parent_slug, string $menu_label ): int {
+		$score = 100;
+
+		if ( '' === $parent_slug ) {
+			$score += 10;
+		}
+
+		if ( $this->is_manage_like_label( $menu_label ) ) {
+			$score += 5;
+		}
+
+		return $score;
+	}
+
+	/**
+	 * Check whether a label looks like a settings/manage destination.
+	 *
+	 * @param string $label Menu label.
+	 * @return bool
+	 */
+	private function is_manage_like_label( string $label ): bool {
+		$label   = strtolower( $label );
+		$needles = array(
+			'settings',
+			'dashboard',
+			'options',
+			'manage',
+			'setup',
+			'welcome',
+			'tools',
+		);
+
+		foreach ( $needles as $needle ) {
+			if ( false !== strpos( $label, $needle ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Write a debug line when local debugging is enabled.
+	 *
+	 * @param string               $plugin_file Plugin basename.
+	 * @param string               $status      accepted|rejected|info.
+	 * @param string               $reason      Reason code.
+	 * @param array<string, mixed> $context     Extra context.
+	 * @return void
+	 */
+	private function debug_log( string $plugin_file, string $status, string $reason, array $context = array() ): void {
+		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
+			return;
+		}
+
+		$payload = array(
+			'plugin' => $plugin_file,
+			'status' => $status,
+			'reason' => $reason,
+			'data'   => $context,
+		);
+
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Temporary local diagnostics for Slice 3 menu ownership analysis.
+		error_log( 'APL_MENU ' . wp_json_encode( $payload ) );
+	}
+}

--- a/includes/class-apl-row-action-discovery.php
+++ b/includes/class-apl-row-action-discovery.php
@@ -1,0 +1,506 @@
+<?php
+/**
+ * Row action based discovery for Active Plugin Locator.
+ *
+ * @package ActivePluginLocator
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Captures conservative medium-confidence candidates from plugin row action links.
+ *
+ * @package ActivePluginLocator
+ */
+final class APL_Row_Action_Discovery {
+
+	/**
+	 * Pending plugin basenames.
+	 *
+	 * @var array<int, string>
+	 */
+	private $pending_plugins = array();
+
+	/**
+	 * Captured candidates keyed by plugin basename.
+	 *
+	 * @var array<string, array<int, array<string, string>>>
+	 */
+	private $results = array();
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array<int, string> $pending_plugins Pending plugin basenames.
+	 */
+	public function __construct( array $pending_plugins ) {
+		$this->pending_plugins = array_values( array_unique( array_filter( $pending_plugins, 'is_string' ) ) );
+	}
+
+	/**
+	 * Register capture hooks.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		if ( empty( $this->pending_plugins ) ) {
+			return;
+		}
+
+		add_filter( 'plugin_action_links', array( $this, 'capture_plugin_action_links' ), 100, 4 );
+	}
+
+	/**
+	 * Capture plausible internal manage links from plugin row actions.
+	 *
+	 * @param array<string, string> $actions     Plugin action links.
+	 * @param string                $plugin_file Plugin basename.
+	 * @param array<string, mixed>  $plugin_data Plugin metadata.
+	 * @param string                $context     Display context.
+	 * @return array<string, string>
+	 */
+	public function capture_plugin_action_links( array $actions, string $plugin_file, array $plugin_data, string $context ): array {
+		unset( $context );
+
+		if ( ! in_array( $plugin_file, $this->pending_plugins, true ) ) {
+			return $actions;
+		}
+
+		$candidates = array();
+
+		foreach ( $actions as $action_key => $action_html ) {
+			$candidate = $this->build_candidate_from_action( (string) $action_key, (string) $action_html, $plugin_file, $plugin_data );
+
+			if ( empty( $candidate ) ) {
+				continue;
+			}
+
+			$candidates[] = $candidate;
+		}
+
+		if ( empty( $candidates ) ) {
+			return $actions;
+		}
+
+		usort(
+			$candidates,
+			static function ( array $left, array $right ): int {
+				return (int) $right['score'] <=> (int) $left['score'];
+			}
+		);
+
+		$deduped = array();
+		$seen    = array();
+
+		foreach ( $candidates as $candidate ) {
+			$dedupe_key = $candidate['url'];
+
+			if ( isset( $seen[ $dedupe_key ] ) ) {
+				continue;
+			}
+
+			$seen[ $dedupe_key ] = true;
+			$deduped[]           = array(
+				'label' => $candidate['label'],
+				'url'   => $candidate['url'],
+			);
+
+			if ( 2 <= count( $deduped ) ) {
+				break;
+			}
+		}
+
+		$this->results[ $plugin_file ] = $deduped;
+
+		return $actions;
+	}
+
+	/**
+	 * Get candidates for a plugin basename.
+	 *
+	 * @param string $plugin_file Plugin basename.
+	 * @return array<int, array<string, string>>
+	 */
+	public function get_candidates( string $plugin_file ): array {
+		return isset( $this->results[ $plugin_file ] ) ? $this->results[ $plugin_file ] : array();
+	}
+
+	/**
+	 * Build a candidate from a plugin row action.
+	 *
+	 * @param string               $action_key  Action key.
+	 * @param string               $action_html Action HTML.
+	 * @param string               $plugin_file Plugin basename.
+	 * @param array<string, mixed> $plugin_data Plugin metadata.
+	 * @return array<string, string|int>
+	 */
+	private function build_candidate_from_action( string $action_key, string $action_html, string $plugin_file, array $plugin_data ): array {
+		$href  = $this->extract_href( $action_html );
+		$label = trim( wp_strip_all_tags( $action_html ) );
+
+		if ( '' === $href || '' === $label ) {
+			$this->debug_log(
+				$plugin_file,
+				'rejected',
+				'missing_href_or_label',
+				array(
+					'action_key' => $action_key,
+					'label'      => $label,
+					'href'       => $href,
+				)
+			);
+
+			return array();
+		}
+
+		$normalized_url = $this->normalize_internal_admin_url( $href );
+		if ( '' === $normalized_url ) {
+			$this->debug_log(
+				$plugin_file,
+				'rejected',
+				'not_internal_wp_admin_url',
+				array(
+					'action_key' => $action_key,
+					'label'      => $label,
+					'href'       => $href,
+				)
+			);
+
+			return array();
+		}
+
+		if ( $this->is_generic_action( $action_key, $label, $normalized_url ) ) {
+			$this->debug_log(
+				$plugin_file,
+				'rejected',
+				'generic_action',
+				array(
+					'action_key' => $action_key,
+					'label'      => $label,
+					'url'        => $normalized_url,
+				)
+			);
+
+			return array();
+		}
+
+		if ( ! $this->looks_plugin_specific( $normalized_url, $plugin_file, $plugin_data, $action_key, $label ) ) {
+			$this->debug_log(
+				$plugin_file,
+				'rejected',
+				'not_plugin_specific',
+				array(
+					'action_key' => $action_key,
+					'label'      => $label,
+					'url'        => $normalized_url,
+				)
+			);
+
+			return array();
+		}
+
+		$candidate = array(
+			'label' => $label,
+			'url'   => esc_url_raw( $normalized_url ),
+			'score' => $this->score_candidate( $action_key, $label, $normalized_url ),
+		);
+
+		$this->debug_log(
+			$plugin_file,
+			'accepted',
+			'medium_confidence_candidate',
+			$candidate
+		);
+
+		return $candidate;
+	}
+
+	/**
+	 * Extract href from an anchor HTML string.
+	 *
+	 * @param string $action_html Action HTML.
+	 * @return string
+	 */
+	private function extract_href( string $action_html ): string {
+		if ( ! preg_match( '/href=(["\'])(.*?)\1/i', $action_html, $matches ) ) {
+			return '';
+		}
+
+		return html_entity_decode( $matches[2], ENT_QUOTES, 'UTF-8' );
+	}
+
+	/**
+	 * Normalize and validate an internal wp-admin URL.
+	 *
+	 * @param string $raw_url Raw URL.
+	 * @return string
+	 */
+	private function normalize_internal_admin_url( string $raw_url ): string {
+		$raw_url = trim( $raw_url );
+		if ( '' === $raw_url ) {
+			return '';
+		}
+
+		$parts       = wp_parse_url( $raw_url );
+		$admin_parts = wp_parse_url( admin_url() );
+
+		if ( false === $parts || false === $admin_parts ) {
+			return '';
+		}
+
+		if ( isset( $parts['host'] ) ) {
+			$admin_host = isset( $admin_parts['host'] ) ? strtolower( (string) $admin_parts['host'] ) : '';
+			$url_host   = strtolower( (string) $parts['host'] );
+
+			if ( '' === $admin_host || $url_host !== $admin_host ) {
+				return '';
+			}
+
+			$path = isset( $parts['path'] ) ? (string) $parts['path'] : '';
+			if ( false === strpos( $path, '/wp-admin/' ) ) {
+				return '';
+			}
+
+			return $raw_url;
+		}
+
+		if ( preg_match( '#^[a-z0-9\-_]+\.php(\?.*)?$#i', $raw_url ) ) {
+			return admin_url( $raw_url );
+		}
+
+		if ( 0 === strpos( ltrim( $raw_url, '/' ), 'wp-admin/' ) ) {
+			return home_url( '/' . ltrim( $raw_url, '/' ) );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Reject clearly generic plugin row actions.
+	 *
+	 * @param string $action_key Action key.
+	 * @param string $label      Action label.
+	 * @param string $url        Normalized URL.
+	 * @return bool
+	 */
+	private function is_generic_action( string $action_key, string $label, string $url ): bool {
+		$generic_keys = array(
+			'activate',
+			'deactivate',
+			'delete',
+			'edit',
+			'resume',
+			'details',
+			'network_activate',
+			'network_deactivate',
+		);
+
+		if ( in_array( strtolower( $action_key ), $generic_keys, true ) ) {
+			return true;
+		}
+
+		$lower_label    = strtolower( $label );
+		$generic_labels = array(
+			'activate',
+			'deactivate',
+			'delete',
+			'edit',
+			'details',
+			'visit plugin site',
+		);
+
+		if ( in_array( $lower_label, $generic_labels, true ) ) {
+			return true;
+		}
+
+		$path = wp_parse_url( $url, PHP_URL_PATH );
+		$path = is_string( $path ) ? basename( $path ) : '';
+
+		$generic_pages = array(
+			'plugins.php',
+			'plugin-install.php',
+			'plugin-editor.php',
+			'update.php',
+		);
+
+		return in_array( $path, $generic_pages, true );
+	}
+
+	/**
+	 * Determine whether a destination looks plugin-specific enough for medium confidence.
+	 *
+	 * @param string               $url         Candidate URL.
+	 * @param string               $plugin_file Plugin basename.
+	 * @param array<string, mixed> $plugin_data Plugin metadata.
+	 * @param string               $action_key  Action key.
+	 * @param string               $label       Action label.
+	 * @return bool
+	 */
+	private function looks_plugin_specific( string $url, string $plugin_file, array $plugin_data, string $action_key, string $label ): bool {
+		$query = wp_parse_url( $url, PHP_URL_QUERY );
+		$vars  = array();
+
+		if ( is_string( $query ) ) {
+			wp_parse_str( $query, $vars );
+		}
+
+		$page      = isset( $vars['page'] ) ? sanitize_key( (string) $vars['page'] ) : '';
+		$post_type = isset( $vars['post_type'] ) ? sanitize_key( (string) $vars['post_type'] ) : '';
+
+		$tokens = $this->build_plugin_tokens( $plugin_file, $plugin_data );
+
+		if ( '' !== $page && $this->contains_any_token( $page, $tokens ) ) {
+			return true;
+		}
+
+		if ( '' !== $post_type && $this->contains_any_token( $post_type, $tokens ) ) {
+			return true;
+		}
+
+		if ( '' !== $page && $this->is_manage_like_action( $action_key, $label ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Assign a score so the most likely candidates appear first.
+	 *
+	 * @param string $action_key Action key.
+	 * @param string $label      Action label.
+	 * @param string $url        Candidate URL.
+	 * @return int
+	 */
+	private function score_candidate( string $action_key, string $label, string $url ): int {
+		$score = 10;
+
+		if ( $this->is_manage_like_action( $action_key, $label ) ) {
+			$score += 30;
+		}
+
+		$query = wp_parse_url( $url, PHP_URL_QUERY );
+		$vars  = array();
+
+		if ( is_string( $query ) ) {
+			wp_parse_str( $query, $vars );
+		}
+
+		if ( ! empty( $vars['page'] ) ) {
+			$score += 20;
+		}
+
+		if ( ! empty( $vars['post_type'] ) ) {
+			$score += 10;
+		}
+
+		return $score;
+	}
+
+	/**
+	 * Check whether an action looks like a manage/settings entry point.
+	 *
+	 * @param string $action_key Action key.
+	 * @param string $label      Action label.
+	 * @return bool
+	 */
+	private function is_manage_like_action( string $action_key, string $label ): bool {
+		$value = strtolower( $action_key . ' ' . $label );
+
+		$needles = array(
+			'settings',
+			'configure',
+			'config',
+			'setup',
+			'wizard',
+			'dashboard',
+			'options',
+			'manage',
+		);
+
+		foreach ( $needles as $needle ) {
+			if ( false !== strpos( $value, $needle ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Build plugin-specific tokens for URL matching.
+	 *
+	 * @param string               $plugin_file Plugin basename.
+	 * @param array<string, mixed> $plugin_data Plugin metadata.
+	 * @return array<int, string>
+	 */
+	private function build_plugin_tokens( string $plugin_file, array $plugin_data ): array {
+		$tokens = array();
+
+		$dir_name  = dirname( $plugin_file );
+		$file_name = basename( $plugin_file, '.php' );
+		$name      = isset( $plugin_data['Name'] ) ? (string) $plugin_data['Name'] : '';
+
+		foreach ( array( $dir_name, $file_name, $name ) as $source ) {
+			$pieces = preg_split( '/[^a-z0-9]+/i', strtolower( $source ) );
+			if ( ! is_array( $pieces ) ) {
+				continue;
+			}
+
+			foreach ( $pieces as $piece ) {
+				if ( 2 >= strlen( $piece ) ) {
+					continue;
+				}
+				$tokens[] = $piece;
+			}
+		}
+
+		return array_values( array_unique( $tokens ) );
+	}
+
+	/**
+	 * Check whether a haystack contains any plugin token.
+	 *
+	 * @param string             $haystack Haystack string.
+	 * @param array<int, string> $tokens   Tokens.
+	 * @return bool
+	 */
+	private function contains_any_token( string $haystack, array $tokens ): bool {
+		$haystack = strtolower( $haystack );
+
+		foreach ( $tokens as $token ) {
+			if ( false !== strpos( $haystack, $token ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Write a debug line when local debugging is enabled.
+	 *
+	 * @param string               $plugin_file Plugin basename.
+	 * @param string               $status      accepted|rejected.
+	 * @param string               $reason      Reason code.
+	 * @param array<string, mixed> $context     Extra context.
+	 * @return void
+	 */
+	private function debug_log( string $plugin_file, string $status, string $reason, array $context = array() ): void {
+		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
+			return;
+		}
+
+		$payload = array(
+			'plugin' => $plugin_file,
+			'status' => $status,
+			'reason' => $reason,
+			'data'   => $context,
+		);
+
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Debug-only local diagnostics for Slice 2 candidate rejection analysis.
+		error_log( 'APL_ROW_ACTION ' . wp_json_encode( $payload ) );
+	}
+}


### PR DESCRIPTION
**Summary**

This PR implements **Slice 3** of Active Plugin Locator by introducing **menu-based discovery** to improve detection coverage beyond row actions. It also adds **structured debug instrumentation** for decision tracing and cleans the repository by removing local WordPress runtime files (`public/wp-content`) from version control.

**Changes**

 **Menu Discovery**

Added `class-apl-menu-discovery.php`.

Detects plugin management locations via:

- `admin_menu` registrations
- submenu pages

Complements existing row-action detection.

**Detection Pipeline**

Combines:

- Row Action Discovery (`class-apl-row-action-discovery.php`)
- Menu Discovery

Expands coverage for plugins that:

- do not expose “Settings” links in plugin rows
- rely solely on admin menu registration

**Debug Instrumentation**

Added structured logging to trace:

- acceptance decisions
- rejection decisions
- scoring outcomes (for example, `medium_confidence_candidate`)

Logs are written to `wp-content/debug.log`.

Example:

```
    APL_ROW_ACTION {
      "plugin": "duplicate-page/duplicatepage.php",
      "status": "accepted",
      "reason": "medium_confidence_candidate",
      "score": 60
    }
```

 **Developer Workflow**

Added `bin/sync-plugin.sh` to eliminate the manual zip/upload workflow.

**Repository Cleanup**

Removed tracked local WordPress runtime files, including:

- `public/wp-content/plugins`
- `public/wp-content/themes`
- `public/wp-content/uploads`
- `public/wp-content/cache`
- other local runtime artifacts under `public/wp-content`

Updated `.gitignore` to prevent re-tracking.

 _Why_

Previously, detection relied on row actions, which limited coverage. For example, only **Duplicate Page** worked reliably.

This change introduces menu discovery, enabling broader and more reliable detection across plugins.

_Known Limitations_

- Menu discovery uses heuristics such as slug/title matching
- Does not yet cover all edge cases, including custom routing and AJAX UIs
- Multisite/network admin is not supported
- Some actions are still classified as `generic_action`

_How to Test_

**Run:**

  ```
  ddev start
    ./bin/sync-plugin.sh

```
Then:

1. Activate the plugin in WP Admin
2. Install and activate:
   - Duplicate Page
   - Redirection
   - Autoptimize
   - Easy WP SMTP

Verify:

- admin toast behavior
- `wp-content/debug.log` entries

## Risks

- Low risk to core WordPress functionality
- Main risk: menu discovery edge cases, mitigated through logging

**## Next Steps**

_- Improve scoring model (confidence weighting)
- Normalize menu slugs vs plugin basename
- Reduce false positives (`generic_action`)
- Add fallback strategies for non-standard plugins_

## KPIs

_- **≥70%** detection success across common plugins
- **<2s** admin load impact
- Debug logs remain bounded_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Toast notifications now display contextual links for activated plugins.

* **Refactor**
  * Restructured toast notification payload building and discovery mechanisms to improve plugin detection and display logic.

* **Chores**
  * Updated plugin author attribution, expanded project configuration for build artifacts and development dependencies, and added code quality tooling scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->